### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.0.11"
 edition = "2021"
 license = "MIT"
 description = "An ACID compliant JSON embeddable database built in Rust."
-homepage = "https://www.github.com/the-devoyage/deeb"
-repository = "https://www.github.com/the-devoyage/deeb"
+homepage = "https://github.com/the-devoyage/deeb"
+repository = "https://github.com/the-devoyage/deeb"
 
 [lib]
 name = "deeb"


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96

You can find out info about all of your crates here: https://rust-digger.code-maven.com/users/nickisyourfan